### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=SODAQ
 maintainer=Kees Bakker <kees@sodaq.net>
 sentence=Allows the communication between devices or sensors connected via Two Wire Interface Bus. For all Arduino boards, BUT Arduino DUE. 
 paragraph=
+category=Communication
 url=http://github.com/SodaqMoja/Wire
 architectures=avr


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library Wire is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6 and 1.6.7.  If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
